### PR TITLE
avoid duplicating initial breakpoints

### DIFF
--- a/build.py
+++ b/build.py
@@ -30,7 +30,10 @@ g_otherSrcDirs = [
             "./tests/ini"
             ]
 g_mainSrcDir = ["./src" ]
-g_requiredPrograms = ["make", "gcc", "ctags" ]
+if platform == "darwin":
+    g_requiredPrograms = ["make", "clang", "ctags" ]
+else:
+    g_requiredPrograms = ["make", "gcc", "ctags" ]
 MIN_QT_VER = "4.0.0"
 #-----------------------------#
 

--- a/src/gd.cpp
+++ b/src/gd.cpp
@@ -70,7 +70,9 @@ void loadBreakpoints(Settings &cfg, Core &core)
     {
         SettingsBreakpoint bkptCfg = cfg.m_breakpoints[i];
         debugMsg("Setting breakpoint at %s:L%d", qPrintable(bkptCfg.m_filename), bkptCfg.m_lineNo);
-        core.gdbSetBreakpoint(bkptCfg.m_filename, bkptCfg.m_lineNo);
+	if (core.findBreakPoint(bkptCfg.m_filename, bkptCfg.m_lineNo) == NULL)
+	  // insert only if not already there
+	  core.gdbSetBreakpoint(bkptCfg.m_filename, bkptCfg.m_lineNo);
     }
 }
 


### PR DESCRIPTION
This change avoids copying the initial breakpoint repeatedly when the option "Use breakpoints from last run" is enabled.