### PR TITLE
build.py: use clang on macos

### DIFF
--- a/build.py
+++ b/build.py
@@ -30,7 +30,10 @@ g_otherSrcDirs = [
             "./tests/ini"
             ]
 g_mainSrcDir = ["./src" ]
-g_requiredPrograms = ["make", "gcc", "ctags" ]
+if platform == "darwin":
+    g_requiredPrograms = ["make", "clang", "ctags" ]
+else:
+    g_requiredPrograms = ["make", "gcc", "ctags" ]
 MIN_QT_VER = "4.0.0"
 #-----------------------------#
 


### PR DESCRIPTION
On macOS: One should ask for the presence of clang instead of gcc.