### PR TITLE
enable select file in open dialog for remote debugging

### DIFF
--- a/src/opendialog.cpp
+++ b/src/opendialog.cpp
@@ -280,6 +280,7 @@ void OpenDialog::onConnectionTypeLocal(bool checked)
 
 void OpenDialog::onConnectionTypeTcp(bool checked)
 {
+    m_ui.pushButton_selectFile->setEnabled(checked);
     m_ui.lineEdit_tcpHost->setEnabled(checked);
     m_ui.lineEdit_tcpPort->setEnabled(checked);
     m_ui.checkBox_download->setEnabled(checked);
@@ -288,6 +289,7 @@ void OpenDialog::onConnectionTypeTcp(bool checked)
 
 void OpenDialog::onConnectionTypeSerial(bool checked)
 {
+    m_ui.pushButton_selectFile->setEnabled(checked);
     m_ui.comboBox_baudRate->setEnabled(checked);
     m_ui.comboBox_serialPort->setEnabled(checked);
     m_ui.checkBox_download->setEnabled(checked);


### PR DESCRIPTION
You cannot select the file name in the opening dialog when you debug remotely. Now the field is enabled in case you debug remotely.