### PR TITLE
build.py: delete app-dir on macOS when cleaning

### DIFF
--- a/build.py
+++ b/build.py
@@ -104,6 +104,8 @@ def doClean():
         removeFile(g_exeName)
         removeFile("Makefile")
         removeFile(".qmake.stash")
+        if platform == "darwin" and os.path.exists(g_exeName + ".app"):
+            shutil.rmtree(g_exeName + ".app")
         os.chdir(oldP)
 
 


### PR DESCRIPTION
On macOS, an app folder containing the binary is generated. When cleaning up, this folder should be deleted.