### PR TITLE
functions in INO files

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -22,7 +22,7 @@
 // etags command and argument to use to get list of tags
 #define ETAGS_CMD1     "ctags"    // Used on Linux
 #define ETAGS_CMD2     "exctags"  // Used on freebsd
-#define ETAGS_ARGS    " -f - --excmd=number --fields=+nmsSk"
+#define ETAGS_ARGS    " -f - --excmd=number --fields=+nmsSk --langmap=c++:+.ino"
 
 
 // Max number of recently used goto locations to save


### PR DESCRIPTION
The Arduino INO files were not included in ctag scanning, so the functions did not appear in the functions window. The .ino file extension had to be added to support this.