### PR TITLE
disabling editable property on baud rate field

### DIFF
--- a/src/opendialog.ui
+++ b/src/opendialog.ui
@@ -230,7 +230,7 @@
             </sizepolicy>
            </property>
            <property name="editable">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
I had the following problem with the *baud rate* input field. After having set it to 115200 once, it will pick up that value when Gede is started the next time, which is intended. However, while this value is shown in the baud rate field, the baud rate is set to the default value of 1200. So, when you start debugging, GDB will not be able to connect to the remote debugger. Only when you explicitly select the baud rate field and hit return is the displayed value used. 

A quick fix for me was to disable the *editable* property of the field. Then, the displayed value is always used.

It is not clear to me whether this is a Qt bug or whether there is a better fix. In any case, this is not an urgent issue anymore because I now use a gdbserver, which provides a connection over an IP port. 