### PR TITLE
startup speedup for older avr-gdb versions

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -516,22 +516,26 @@ int Core::initRemote(Settings *cfg, QString gdbPath, QString programPath, QStrin
         return -1;
     }
 
-    com.commandF(&resultData, "-target-select extended-remote %s:%d", stringToCStr(tcpHost), tcpPort); 
-
     if(!programPath.isEmpty())
     {
         com.commandF(&resultData, "-file-symbol-file %s", stringToCStr(programPath));
 
     }
 
-    runInitCommands(cfg);
-
     if(!programPath.isEmpty())
     {
       com.commandF(&resultData, "-file-exec-file %s", stringToCStr(programPath));
 
-        if(cfg->m_download)
-            com.commandF(&resultData, "-target-download");
+    }
+
+    com.commandF(&resultData, "-target-select extended-remote %s:%d", stringToCStr(tcpHost), tcpPort); 
+
+    runInitCommands(cfg);
+
+    if(!programPath.isEmpty())
+    {
+      if(cfg->m_download)
+	com.commandF(&resultData, "-target-download");
     }
     
     // Get memory depth (32 or 64)
@@ -566,23 +570,25 @@ int Core::initSerial(Settings *cfg, QString gdbPath, QString programPath, QStrin
 
     com.commandF(&resultData, "set serial baud %d", baudRate); 
 
-    com.commandF(&resultData, "-target-select extended-remote %s", stringToCStr(serialPort)); 
-
-
     if(!programPath.isEmpty())
     {
         com.commandF(&resultData, "-file-symbol-file %s", stringToCStr(programPath));
 
     }
 
+    if(!programPath.isEmpty())
+    {
+      com.commandF(&resultData, "-file-exec-file %s", stringToCStr(programPath));
+    }
+    
+    com.commandF(&resultData, "-target-select extended-remote %s", stringToCStr(serialPort)); 
+
     runInitCommands(cfg);
 
     if(!programPath.isEmpty())
     {
-      com.commandF(&resultData, "-file-exec-file %s", stringToCStr(programPath));
-
-        if(cfg->m_download)
-            com.commandF(&resultData, "-target-download");
+      if(cfg->m_download)
+	com.commandF(&resultData, "-target-download");
     }
     
     // Get memory depth (32 or 64)


### PR DESCRIPTION
Gede used to communicate with the remote target for 20 seconds when starting up when using an older version of avr-gdb (<15.2). The command avr-gdb sends to the target looks very strange. Apparently, this is caused by executing the target-select command without having specified a binary file before (my best guess is that an uninitialized variable in GDB causes this). Executing file-symbols-file and file-exec-file before target-select avoids this problem.

With the current avr-gdb (15.2), this does not happen anymore. Also with avr-gdb 10.1.90 under Ubuntu, I could not replicate the problem. So, it is probably not an urgent patch. 