### PR TITLE
Add support for OpenIndiana

### DIFF
--- a/AppDir/gede.desktop
+++ b/AppDir/gede.desktop
@@ -1,6 +1,9 @@
 [Desktop Entry]
+Version=1.0
 Name=Gede
+Comment=GUI for the GNU/GDB debugger
+Exec=gede
+Icon=gede_icon.png
 Icon=gede_icon
 Type=Application
-Categories=Utility;Development;
-
+Categories=Programming;C/C++;Utility;Development;

--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Written by Johan Henriksson. Copyright (C) 2014-2024.
+# Copyright (C) 1.6.2025 by benny.lyons@gmx.net
 #
 import sys
 import os
@@ -66,7 +67,10 @@ def run_program(program_name, a_list, verbose = False):
 
 # Run make
 def run_make(a_list, verbose = False):
-    return run_program("make", a_list, verbose)
+    if platform[:3] == 'sun':
+        return run_program("gmake", a_list, verbose)
+    else:
+        return run_program("make", a_list, verbose)
 
 # Remove a file
 def removeFile(filename):


### PR DESCRIPTION
Illumos/OpenIndiana are forks of the old Open Solaris//Oracle Solaris.

The port was remarkably easy.  I didn't have to touch any C++ code!!! A small modificatin to build.py, added a few paths to PATH, gede.desktop was modified (otherwise the Mate desktop refused to add the menu entry) and the addition of a few dependencies and the build went fine.

I started gede on a simple project and set  a couple of breakpoints and it would appear to be working fine.
Are there any tests I could run?