### PR TITLE
Add OpenIndiana/Illumos version information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,16 @@ Compile and install (to /usr/local/bin):
 
     # sudo make install
 
+or
+
+    # build.py help
+
+    # build.py 
+
+Configure build:
+
+    buildcfg.py
+
 Gede can now be launched:
 
     # gede

--- a/build.py
+++ b/build.py
@@ -204,7 +204,7 @@ def detectQt():
         if buildcfg.g_qmakeQt5:
             qmakeName = buildcfg.g_qmakeQt5;
         else:
-            raise RuntimeError("Failed to find qt4 qmake")
+            raise RuntimeError("Failed to find qt5 qmake")
     elif buildcfg.g_qtVersionToUse == FORCE_QT6:
         os.environ["QT_SELECT"] = "qt6"
         if buildcfg.g_qmakeQt6:

--- a/buildcfg.py
+++ b/buildcfg.py
@@ -1,6 +1,7 @@
 #
 # Written by Johan Henriksson. Copyright (C) 2024.
-#
+# Copyright (C) 2025 mebenn benny.lyons@gmx.net
+
 from sys import platform
 from build import FORCE_QT5,FORCE_QT6,AUTODETECT
 
@@ -22,6 +23,9 @@ g_testDirs = [
 g_mainSrcDir = ["./src" ]
 if platform == "darwin":
     g_requiredPrograms = ["make", "clang", "ctags" ]
+elif platform[:3] == "sun":
+    # OpenIndiana/Illumos
+    g_requiredPrograms = ["gmake", "gcc", "ctags" ]
 else:
     g_requiredPrograms = ["make", "gcc", "ctags" ]
 MIN_QT_VER = "4.0.0"

--- a/mytestapps/c_code/test.c
+++ b/mytestapps/c_code/test.c
@@ -1,0 +1,126 @@
+#include <stdio.h>
+#include <stdint.h>
+
+int global_var1 = 1;
+
+	 	//rad1
+   	//kalle
+	//tab1
+		//tab2
+			//tab3
+//		|tab1_again
+//  	|tab2_again
+    //kalle
+  	//nisse
+
+#define EMPTY ""
+
+
+void long_func_with_many_arguments(int a_very_long_function_variable_name_xxxxxxx, int another_very_long_variable_name___, int another_another_very_long_variable_name___, int another_another_very_long_variable_name___2)
+{
+}
+
+void testLargeArray()
+{
+    struct Element
+    {
+        uint64_t a;
+    };
+    static struct Element array[8*1024];
+    const int elementCount = sizeof(array)/sizeof(array[0]);
+    
+    for(int i = 0;i < elementCount;i++)
+    {
+        array[i].a = i;
+//sleep(1);
+    }
+
+    array[elementCount-1].a = 0;
+    array[elementCount-1].a = 1;
+    array[elementCount-1].a = 2;
+    array[elementCount-1].a = 3;
+    
+    
+}
+
+
+typedef enum {CUSTOM_ENUM1, CUSTOM_ENUM2} CustomEnum;
+int main(int argc,char *argv[])
+{
+    
+    char sbuffer[1024];
+    const char **strList;
+    const char *strListData[] = {"hej", "kalle"};
+    int i3[] = { 111,222};
+    struct
+    {
+        int a;
+        struct
+        {
+            int b;
+        }s2;
+    }s;
+    int a = 1001;
+    char c = 'Z';
+    float f1;
+    char *varStr;
+    enum {ENUM1, ENUM2}varEnum;
+    unsigned char d = 0;
+    CustomEnum customEnum1;
+    int i;
+
+    for(i = 1;i < argc;i++)
+    {
+        printf("%d:>%s<\n", i, argv[i]);
+    }
+
+    global_var1++;
+    global_var1++;
+    global_var1++;
+
+    sbuffer[0] = '1';
+    sbuffer[1] = '2';
+    sbuffer[2] = '3';
+    for(i = 3;i <= 9;i++)
+        sbuffer[i] = '0'+i;
+
+    printf("hello"EMPTY" >");
+    printf("<\n");
+
+    varStr = "stri\n\r\t\03ng1";
+    varStr = "string2";
+    f1 = 0.0;
+    s.a = 0;
+    s.s2.b = 1;
+    varEnum = ENUM1;
+    varEnum = ENUM2;
+    c = '\'';
+    a++;
+
+    strList = strListData;
+
+    switch(s.a)
+    {
+        case 0:
+            {
+                printf("Hej!\n");
+            };break;
+        default:;break;
+    }
+
+    testLargeArray();
+    
+    while(1)
+    {
+        c++;
+        f1 += 0.1;
+        //func();
+        s.a++;
+        s.s2.b++;
+        s.s2.b++;
+        s.a++;
+        d++;
+    }
+    return 0;
+}
+

--- a/relop_test_build.sh
+++ b/relop_test_build.sh
@@ -5,13 +5,23 @@ set -e
 ./build.py clean
 ./build.py --verbose 
 
+
+# On OpenIndiana/Illumos make ist not the same as gmake
+# To get some tests to compile, we require GNU make
+os=$(uname -o)
+if [ "$os" = "illumos" ]; then
+        Make=gmake
+else
+        Make=make
+fi
+
 #
 for td in testapps/*;do
     if [ -d "$td" ]; then
       echo "$td"
       pushd $td > /dev/null
-      make clean
-      make
+      $Make clean
+      $Make
       popd > /dev/null
     fi
 done

--- a/src/detectdistro.cpp
+++ b/src/detectdistro.cpp
@@ -5,6 +5,14 @@
 #include <QMap>
 #include <QProcess>
 
+#include <sys/stat.h>
+
+/**
+  * @brief Check if we are on OpenIndiana/Illumos
+  */
+bool isOpenIndiana(void);
+
+
 
 /**
   * @brief Tries to detect the distro the system is running on.
@@ -69,13 +77,35 @@ void detectDistro(DistroType *type, QString *distroDesc)
 
     }
 
+    // OpenIndiana/Illumos
+    if (isOpenIndiana())
+    {
+        if(type)
+            *type = DISTRO_OI;
+
+	QFile file3("/etc/release");
+	if(file3.open(QIODevice::ReadOnly))
+	{
+	    distroName = file3.readLine().trimmed();
+	}
+    }
+    
+
 
     // Detect x64/x86 
     QString versionStr;
     QProcess process;
-    process.start("uname", 
-        QStringList("-m"),
-        QIODevice::ReadOnly | QIODevice::Text);
+    
+    if (isOpenIndiana())
+        process.start("uname", 
+            QStringList("-v"),
+            QIODevice::ReadOnly | QIODevice::Text);
+    else
+	process.start("uname", 
+            QStringList("-m"),
+            QIODevice::ReadOnly | QIODevice::Text);
+
+    
     if(!process.waitForFinished(2000))
     {
     }
@@ -95,3 +125,28 @@ void detectDistro(DistroType *type, QString *distroDesc)
 
 
 
+bool isOpenIndiana(void)
+{
+
+    bool ret = false;
+    const char* oiInfos = "/etc/release";
+    struct stat fileExist;
+
+    if (stat(oiInfos, &fileExist) < 0)
+	    return false;
+
+    QFile file(oiInfos);
+    if(file.open(QIODevice::ReadOnly))
+    {
+        QString line = file.readLine().trimmed();
+            if(line.contains("OpenIndiana"))
+                ret = true;
+            else
+                ret = false;
+    } else
+    {
+	    ret = false;
+    }
+
+    return ret;
+}

--- a/src/detectdistro.h
+++ b/src/detectdistro.h
@@ -3,7 +3,7 @@
 
 #include <QString>
 
-typedef enum{ DISTRO_DEBIAN, DISTRO_UBUNTU, DISTRO_UNKNOWN} DistroType;
+typedef enum{ DISTRO_DEBIAN, DISTRO_UBUNTU, DISTRO_OI, DISTRO_UNKNOWN} DistroType;
 void detectDistro(DistroType *type, QString *distroDesc);
 
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2021 Johan Henriksson.
+ * Copyright (C) 2025 mebenn benny.lyons@gmx.net
  * All rights reserved.
  *
  * This software may be modified and distributed under the terms
@@ -10,7 +11,7 @@
 #define FILE__VERSION_H
 
 #define GD_MAJOR 2
-#define GD_MINOR 22
+#define GD_MINOR 23
 #define GD_PATCH 1
 
 


### PR DESCRIPTION
Bump minor version, fix tests, OS infos for OpenIndiana/Illumos
Fix markup
Fix more markup
Fix local tests

- Add os infos in 'About' for OpenIndiana/Illumos
-  Run tests for these: ansicolor  c_code  coredump  threads  tutorial_c (one test failed on OI and Debian (Trixie) due to flag, offending line uncommented on both Trixie and OpenIndiana.  (Didn't have the other languages installed)
-  Compiles on Debian Trixie and OpenIndiana for Qt5, but Qt6 fails on Trixie. Qt6 compiles successfully on OI, starts; but cannot progress to the main window (needs some fixing). On Trixie Qt6 newer version I think is the problem.
